### PR TITLE
Bugfix/handle no kernel situations where config is missing

### DIFF
--- a/scripts/kernel
+++ b/scripts/kernel
@@ -180,6 +180,8 @@ install_new_kernel()
 	then
 		println "Generating a default configuration"
 		make defconfig
+		echo "After you are done with customizing the default kernel configuration, run 'kernel -r' to compile the kernel."
+		exit 1
 	else
 		println "Copying kernel configurations"
 		sudo cp -v $OLD_CONFIG_PATH /usr/src/linux-$VERSION/

--- a/scripts/kernel
+++ b/scripts/kernel
@@ -162,8 +162,19 @@ install_new_kernel()
 	cd /usr/src/linux
 	sudo make mrproper
 
-	println "Copying kernel configurations"
-	sudo cp -v /usr/src/linux-$CURRENT_KERNEL_VERSION/.config /usr/src/linux-$VERSION/
+	# If we didn't earlier have any kernels, we need to generate a default
+	# config file.
+	#
+	# This should also handle cases where the configs have gone missing
+	OLD_CONFIG_PATH="/usr/src/linux-$CURRENT_KERNEL_VERSION/.config"
+	if [ ! -f $OLD_CONFIG_PATH ]
+	then
+		println "Generating a default configuration"
+		make defconfig
+	else
+		println "Copying kernel configurations"
+		sudo cp -v $OLD_CONFIG_PATH /usr/src/linux-$VERSION/
+	fi
 
 	println "Updating the kernel configuration file"
 	sudo make oldconfig

--- a/scripts/kernel
+++ b/scripts/kernel
@@ -46,6 +46,15 @@ reinstall()
 		exit 1
 	fi
 
+	# Check if there's a usable .config file
+	if [ ! -f /usr/src/linux/.config ]
+	then
+		println WARNING "There's no .config file in /usr/src/linux. Creating a new default one"
+		make defconfig
+		echo "New default config created. Customize it to your needs and after you are done, run 'kernel -r'"
+		exit 1
+	fi
+
 	println "Compiling the kernel"
 	cd /usr/src/linux
 	sudo make -j$(nproc)


### PR DESCRIPTION
Continuation for https://github.com/birb-linux/birb-utils/pull/1

This pull request fixes situations where there might be no .config file in /usr/src/linux and thus the kernel configurations are unclear. The script will in these situations now create a default configuration for the user to customize